### PR TITLE
Updated the regular expression for a more accurate and faster search

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ add_filter('wpacu_html_source_before_optimization', function($htmlSource) {
 	);
 
 	// This RegEx looks inside a class' content (either within single or double quote) and checks if it has the classes mentioned at $checkIfClassContains
-	$verifyRegEx = '#class=("|\').*('.$containsListRegEx.')(.*?)("|\')(.*?)>#';
+	$verifyRegEx = '#class=("|\')[^"|\']*\b'.$containsListRegEx.'\b[^"|\']*?\1#';
 
 	preg_match_all($verifyRegEx, $htmlSource, $anyMatches);
 


### PR DESCRIPTION
As discussed here ( https://wordpress.org/support/topic/cant-find-swiper-elementor-on-asset-cleanup/?#post-14659293 ) I propose this change.